### PR TITLE
Docker build windows

### DIFF
--- a/docker-config/runDocker.sh
+++ b/docker-config/runDocker.sh
@@ -3,14 +3,22 @@
 # s/init/run/g if the image already exists
 
 # init the apach web server
-./apache/runWebServer.sh
+cd apache/
+./runWebServer.sh
+cd ../
 
 # init the database
-./database/runDatabase.sh
+cd database/
+./runDatabase.sh
+cd ../
 
 # init the webserver
-./appserver/runAppServer.sh
+cd appserver
+./runAppServer.sh
+cd ../
 
 # init test webserver
-./appserver_integration_tests/runAppServer.sh
+cd appserver_integration_tests/
+./runAppServer.sh
+cd ../
 

--- a/jee7-class-service/src/test/resources/arquillian.xml
+++ b/jee7-class-service/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
 	<container qualifier="wildfly" default="true">
 		<configuration>
 			<property name="managementAddress">localhost</property>
-			<property name="managementPort">9970</property>
+			<property name="managementPort">9990</property>
 			<property name="username">admin</property>
 			<property name="password">admin</property>
 		</configuration>

--- a/jee7-grade-service/src/test/resources/arquillian.xml
+++ b/jee7-grade-service/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
 	<container qualifier="wildfly" default="true">
 		<configuration>
 			<property name="managementAddress">localhost</property>
-			<property name="managementPort">9970</property>
+			<property name="managementPort">9990</property>
 			<property name="username">admin</property>
 			<property name="password">admin</property>
 		</configuration>

--- a/jee7-students-service/src/test/resources/arquillian.xml
+++ b/jee7-students-service/src/test/resources/arquillian.xml
@@ -7,7 +7,7 @@
 	<container qualifier="wildfly" default="true">
 		<configuration>
 			<property name="managementAddress">localhost</property>
-			<property name="managementPort">9970</property>
+			<property name="managementPort">9990</property>
 			<property name="username">admin</property>
 			<property name="password">admin</property>
 		</configuration>


### PR DESCRIPTION
To solve the error on Windows system:
`unable to prepare context: unable to evaluate symlinks in Dockerfile path: `

You need to be in the right folder when you do : 
`docker build -t jee7-demo-* .`

I change the `runDocker.sh` in this way.
